### PR TITLE
added before open hook

### DIFF
--- a/src/social-sharing.js
+++ b/src/social-sharing.js
@@ -100,7 +100,7 @@ export default {
       type: String,
       default: 'span'
     },
-    
+
     /**
      * Before open window hook: useful to execute async tasks before sharing
      */

--- a/src/social-sharing.js
+++ b/src/social-sharing.js
@@ -99,6 +99,14 @@ export default {
     networkTag: {
       type: String,
       default: 'span'
+    },
+    
+    /**
+     * Before open window hook: useful to execute async tasks before sharing
+     */
+    beforeOpen: {
+      type: Function,
+      default: Promise.resolve
     }
   },
 
@@ -155,8 +163,12 @@ export default {
      * @param string network Social network key.
      */
     share (network) {
-      this.openSharer(network, this.createSharingUrl(network));
-      this.$root.$emit('social_shares_open', network, this.url);
+      this.openSharer(network, '');
+      this.beforeOpen()
+        .then(() => {
+          this.popup.window.location = this.createSharingUrl(this.url);
+          this.$root.$emit('social_shares_open', network, this.url);
+        });
     },
 
     /**


### PR DESCRIPTION
this is a PoC of a "before open" hook: an user could perform async tasks before loading the sharer window.
missing e2e.