### PR TITLE
telegram fix on IOS

### DIFF
--- a/src/networks.json
+++ b/src/networks.json
@@ -46,7 +46,7 @@
   },
 
   "telegram": {
-    "sharer": "https://t.me/share/url?url=@description%0D%0A@url",
+    "sharer": "https://t.me/share/url?url=@url&text=@description",
     "type": "popup"
   },
 


### PR DESCRIPTION
In IOS devices telegram open chat empty. Example correct share: https://telegram.org/blog in 'forward'