### PR TITLE
Add SMS Network

### DIFF
--- a/src/networks.json
+++ b/src/networks.json
@@ -68,5 +68,10 @@
     "sharer": "whatsapp://send?text=@description%0D%0A@url",
     "type": "direct",
     "action": "share/whatsapp/share"
+  },
+  
+  "sms": {
+    "sharer": "sms:?body=@description",
+    "type": "direct"
   }
 }

--- a/test/unit/test.js
+++ b/test/unit/test.js
@@ -155,7 +155,7 @@ describe('SocialSharing', () => {
   it('has a full list of networks', () => {
     for (var network in Networks) {
       expect(typeof Networks[network].sharer).toBe('string');
-      expect(Networks[network].type).toBe(['whatsapp', 'email'].indexOf(network) > -1 ? 'direct' : 'popup');
+      expect(Networks[network].type).toBe(['whatsapp', 'email', 'sms'].indexOf(network) > -1 ? 'direct' : 'popup');
     }
   });
 


### PR DESCRIPTION
When plugin is used on a device browser (or in Cordova app for example), you may need to share content by sms (to ensure compatibility on all iOS versions use https://github.com/smeeckaert/sms-link)