### PR TITLE
fix: Share URL for Emial & SMS, and add missing`via=` for Twitter

### DIFF
--- a/src/networks.json
+++ b/src/networks.json
@@ -1,6 +1,6 @@
 {
   "email": {
-    "sharer": "mailto:?subject=@title&body=@description",
+    "sharer": "mailto:?subject=@title&body=@url%0D%0A%0D%0A@description",
     "type": "direct"
   },
 
@@ -50,7 +50,7 @@
   },
 
   "twitter": {
-    "sharer": "https://twitter.com/intent/tweet?text=@title&url=@url&hashtags=@hashtags@twitteruser",
+    "sharer": "https://twitter.com/intent/tweet?text=@title&url=@url&hashtags=@hashtags&via=@twitteruser",
     "type": "popup"
   },
 
@@ -71,7 +71,7 @@
   },
   
   "sms": {
-    "sharer": "sms:?body=@description",
+    "sharer": "sms:?body=@url%20@description",
     "type": "direct"
   }
 }


### PR DESCRIPTION
Addresses Issue #45 
