### PR TITLE
Allow v-if with transition

### DIFF
--- a/src/social-sharing-network.js
+++ b/src/social-sharing-network.js
@@ -16,7 +16,7 @@ export default {
       return console.warn(`Network ${context.props.network} does not exist`);
     }
 
-    if (!!willrender) {
+    if (willrender) {
       return createElement(context.parent.networkTag, {
         staticClass: context.data.staticClass || null,
         staticStyle: context.data.staticStyle || null,

--- a/src/social-sharing-network.js
+++ b/src/social-sharing-network.js
@@ -10,30 +10,34 @@ export default {
 
   render: (createElement, context) => {
     const network = context.parent._data.baseNetworks[context.props.network];
+    const willrender = context.parent.willRender;
 
     if (!network) {
       return console.warn(`Network ${context.props.network} does not exist`);
     }
 
-    return createElement(context.parent.networkTag, {
-      staticClass: context.data.staticClass || null,
-      staticStyle: context.data.staticStyle || null,
-      class: context.data.class || null,
-      style: context.data.style || null,
-      attrs: {
-        id: context.data.attrs.id || null,
-        'data-link': network.type === 'popup'
-          ? '#share-' + context.props.network
-          : context.parent.createSharingUrl(context.props.network),
-        'data-action': network.type === 'popup' ? null : network.action
-      },
-      on: {
-        click: network.type === 'popup' ? () => {
-          context.parent.share(context.props.network);
-        } : () => {
-          context.parent.touch(context.props.network);
+    if (!!willrender) {
+      return createElement(context.parent.networkTag, {
+        staticClass: context.data.staticClass || null,
+        staticStyle: context.data.staticStyle || null,
+        class: context.data.class || null,
+        style: context.data.style || null,
+        key: context.data.key || null,
+        attrs: {
+          id: context.data.attrs.id || null,
+          'data-link': network.type === 'popup'
+            ? '#share-' + context.props.network
+            : context.parent.createSharingUrl(context.props.network),
+          'data-action': network.type === 'popup' ? null : network.action
+        },
+        on: {
+          click: network.type === 'popup' ? () => {
+            context.parent.share(context.props.network);
+          } : () => {
+            context.parent.touch(context.props.network);
+          }
         }
-      }
-    }, context.children);
+      }, context.children);
+    }
   }
 };

--- a/src/social-sharing.js
+++ b/src/social-sharing.js
@@ -19,7 +19,14 @@ export default {
       type: String,
       default: inBrowser ? window.location.href : ''
     },
-
+    /**
+     * will render.
+     * @var bool
+    */
+    willRender: {
+      type: Boolean,
+      default: false
+    },
     /**
      * Sharing title, if available by network.
      * @var string


### PR DESCRIPTION
Added a **willRender** prop to **social-sharing** comp, and **key** prop to **network** comps
for easily transitioning the social sharing icons with the normal Vue **v-if** and **transition** options.