### PR TITLE
move vue package to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "rollup-plugin-replace": "^1.1.0",
     "selenium-server": "2.53.1",
     "uglify-js": "^2.6.1",
-    "vue": "^2.2.4",
     "webpack": "^1.12.9",
     "webpack-dev-server": "^1.14.1"
   },
@@ -98,6 +97,7 @@
     "test:unit": "karma start config/karma.unit.conf.js"
   },
   "dependencies": {
+    "vue": "^2.2.4",
     "rollup-plugin-json": "^2.1.0"
   }
 }


### PR DESCRIPTION
When I compiled my project with brunch prod mode I see the error in the browser console:
```
Uncaught Error: Cannot find module 'vue' from 'vue-social-sharing/dist/vue-social-sharing.common.js'
```