### PR TITLE
Fix unsolved #143

### DIFF
--- a/src/social-sharing.js
+++ b/src/social-sharing.js
@@ -161,14 +161,14 @@ export default {
         network += '_ios';
       }
 
-      const url = this.baseNetworks[network].sharer;
+      let url = this.baseNetworks[network].sharer;
 
       /**
        * On IOS, Twitter sharing shouldn't include a hashtag parameter if the hashtag value is empty
        * Source: https://github.com/nicolasbeauvais/vue-social-sharing/issues/143
         */
       if (network === 'twitter' && this.hashtags.length === 0) {
-        url.replace('&hashtags=@hashtags', '');
+        url = url.replace('&hashtags=@hashtags', '');
       }
 
       return url


### PR DESCRIPTION
As I tested, __v2.4.5__ doesn't fixed #143 

For the replace method returns a new string with some or all matches of a pattern replaced by a replacement but the original string is left __unchanged__.
