### PR TITLE
(fix): Add HTML5 future-proof SocialSharingNetwork alias

### DIFF
--- a/src/social-sharing.js
+++ b/src/social-sharing.js
@@ -302,6 +302,7 @@ export default {
    * Set component aliases for buttons and links.
    */
   components: {
-    'network': SocialSharingNetwork
+    'network': SocialSharingNetwork,
+    'social-sharing-network': SocialSharingNetwork,
   }
 };

--- a/src/social-sharing.js
+++ b/src/social-sharing.js
@@ -303,6 +303,6 @@ export default {
    */
   components: {
     'network': SocialSharingNetwork,
-    'social-sharing-network': SocialSharingNetwork,
+    'social-sharing-network': SocialSharingNetwork
   }
 };


### PR DESCRIPTION
## The issue
Currently the `SocialSharingNetwork` component is using a single word component name. 

This is conflicting with an essential error prevention rule in the official Vue.js Style Guide. If a native HTML tag was to be implemented with the tag `<network>` the plugin would most likely break.
- [Vue.js Style Guide](https://vuejs.org/v2/style-guide/#Multi-word-component-names-essential)
- [HTML5 Spec - Custom Elements](https://html.spec.whatwg.org/multipage/custom-elements.html)

## Explanation of implementation
I simply added the component again with its original component name, so it can be used properly while keeping backwards compatibility in mind.

I have no idea whether registering the component twice has any performance impacts. If it does, this could be introduced in the next major version instead.

Let me know what you think