### PR TITLE
Improvement: Move Vue to peer dependencies for better bundling experience

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "test:e2e": "npm run build && node test/e2e/runner.js",
     "test:unit": "karma start config/karma.unit.conf.js"
   },
-  "dependencies": {
+  "peerDependencies": {
     "vue": "^2.2.4"
   }
 }


### PR DESCRIPTION
Moving vue from dependencies to peer dependencies prevents module bundlers to include second Vue package into the whole bundle. This should reduce bundle sizes.