### PR TITLE
Add unique name on open new window

### DIFF
--- a/src/share-network.js
+++ b/src/share-network.js
@@ -220,7 +220,7 @@ export default {
 
       this.popupWindow = $window.open(
         this.shareLink,
-        'sharer',
+        `sharer-${this.key}`,
         ',height=' + this.popup.height +
         ',width=' + this.popup.width +
         ',left=' + this.popupLeft +

--- a/src/share-network.js
+++ b/src/share-network.js
@@ -220,7 +220,7 @@ export default {
 
       this.popupWindow = $window.open(
         this.shareLink,
-        `sharer-${this.key}`,
+        'sharer-' + this.key,
         ',height=' + this.popup.height +
         ',width=' + this.popup.width +
         ',left=' + this.popupLeft +

--- a/tests/test.js
+++ b/tests/test.js
@@ -155,7 +155,7 @@ describe('SocialSharing', () => {
       ...fakeWindow,
       open: (url, sharer) => {
         expect(url).toBe(shareNetwork.vm.shareLink)
-        expect(sharer).toBe('sharer')
+        expect(sharer).toBe('sharer-facebook')
 
         popupCreated = true
 


### PR DESCRIPTION
Due to issue [#235](https://github.com/nicolasbeauvais/vue-social-sharing/issues/235) its necessary to set different name to windows to avoid the issue on open new windows (`Permission denied to access property "ob" on cross-origin object`). I added the key to the name, so name will be like as  `sharer-whatsapp` or `sharer-facebook`.