### PR TITLE
Improve accessibility with element focus

### DIFF
--- a/src/share-network.js
+++ b/src/share-network.js
@@ -182,6 +182,9 @@ export default {
 
     return createElement(this.tag, {
       class: 'share-network-' + this.key,
+      attrs: {
+        href: '#'
+      },
       on: {
         click: () => this[this.rawLink.substring(0, 4) === 'http' ? 'share' : 'touch']()
       }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -17,6 +17,6 @@ export interface PluginOptions {
   networks: Record<string, string>
 }
 
-type VueSocialSharing = PluginObject<PluginOptions>
+declare const VueSocialSharing: PluginObject<PluginOptions>
 
 export default VueSocialSharing


### PR DESCRIPTION
- Just a small improvement on accessibility where anchor element needs a href attribute in order to gain keyboard focus
- Resolve linting issue on typing where 'VueSocialSharing' only refers to a type but is being used as a value.