### PR TITLE
Vue router history mode support

### DIFF
--- a/src/share-network.js
+++ b/src/share-network.js
@@ -187,7 +187,7 @@ export default {
       }
     }
 
-    if (this.tag === 'a') node.attrs = { href: '#' }
+    if (this.tag === 'a') node.attrs = { href: 'javascript:void(0)' }
 
     return createElement(this.tag, node, this.$slots.default)
   },


### PR DESCRIPTION
According to #263 issue plugin does not support Vue router's [history](https://router.vuejs.org/guide/essentials/history-mode.html) mode. When click on "share" link page reloading.

This small pull request changes `href` attribute from `#` to `javascript:void(0)` to avoid page reload.

