### PR TITLE
Add support for options on vue3

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,18 +177,17 @@ You can listen to a `ShareNetwork` local event by using the following code:
 In version `3.x` you can extend and override the list of available networks. You can see a working example of the feature in the `examples/index.js` file:
 
 ```javascript
-import Vue from 'vue'
+import { createApp } from 'vue'
 import VueSocialSharing from '@/vue-social-sharing'
 
-Vue.use(VueSocialSharing, {
+const app = createApp(App)
+app.use(VueSocialSharing, {
   networks: {
     fakeblock: 'https://fakeblock.com/share?url=@url&title=@title'
   }
 })
 
-new Vue({
-  el: '#app',
-})
+app.mount('#app')
 ```
 
 ## Extending the network list in Nuxt

--- a/src/share-network.js
+++ b/src/share-network.js
@@ -10,6 +10,18 @@ export function mockWindow (self) {
 export default {
   name: 'ShareNetwork',
 
+  inject: {
+    /**
+     * Options containing custom (extra) networks defined by the user
+     */
+    options: {
+      from: 'shareNetworkOptions',
+      default: {
+        networks: null
+      }
+    }
+  },
+
   props: {
     /**
      * Name of the network to display.
@@ -92,13 +104,6 @@ export default {
       default: () => ({
         width: 626,
         height: 436
-      })
-    },
-
-    options: {
-      type: Object,
-      default: () => ({
-        networks: null
       })
     }
   },

--- a/src/vue-social-sharing.js
+++ b/src/vue-social-sharing.js
@@ -3,6 +3,7 @@ import ShareNetwork from './share-network'
 export default {
   install: (app, options) => {
     app.component(ShareNetwork.name, ShareNetwork)
+    app.provide('shareNetworkOptions', options)
   }
 }
 

--- a/tests/test.js
+++ b/tests/test.js
@@ -42,7 +42,14 @@ function mountShareNetwork (data = {}) {
   return mount(ShareNetwork, {
     propsData: data.propsData,
     attrs: data.attrs,
-    localVue
+    localVue,
+    global: {
+      provide: {
+        'shareNetworkOptions': {
+          networks: customNetworks
+        }
+      }
+    }
   })
 }
 


### PR DESCRIPTION
As it is not possible to use prototype in vue3 anymore, we could now use the provide/inject approach to send our options to each components