### PR TITLE
Allow to run with vue/compat

### DIFF
--- a/src/share-network.js
+++ b/src/share-network.js
@@ -9,7 +9,9 @@ export function mockWindow (self) {
 
 export default {
   name: 'ShareNetwork',
-
+  compatConfig: {
+    MODE: 3,
+  },
   props: {
     /**
      * Name of the network to display.


### PR DESCRIPTION
Hi, @nicolasbeauvais

Most of developers would be using `@vue/compat` build to migrate their codebase to vue 3.
But the "next" branch is not working with `@vue/compat`, the default slot does not render at-all.

I have added the compact config to tell the compiler that this package is using vue 3 syntax, and compiler wont patch this component for vue 3.

https://v3-migration.vuejs.org/migration-build.html#per-component-config

Please merge and release new a version. 
+
Would you accept a PR to generate un-minified file in dist folder along with `.min.js`  ?